### PR TITLE
Initialize the state of the encoders as on.

### DIFF
--- a/src/EncoderManagerPanel.tsx
+++ b/src/EncoderManagerPanel.tsx
@@ -21,9 +21,9 @@ interface SetBoolResponse { // Renamed from EncoderManagerResponse
 function EncoderManagerPanel({ context }: { context: PanelExtensionContext }): ReactElement {
   const [feedback, setFeedback] = useState<string>('');
   // State to track the on/off status of each camera's encoder
-  const [isRoverEncoderOn, setIsRoverEncoderOn] = useState<boolean>(false);
-  const [isArm0EncoderOn, setIsArm0EncoderOn] = useState<boolean>(false);
-  const [isArm1EncoderOn, setIsArm1EncoderOn] = useState<boolean>(false);
+  const [isRoverEncoderOn, setIsRoverEncoderOn] = useState<boolean>(true);
+  const [isArm0EncoderOn, setIsArm0EncoderOn] = useState<boolean>(true);
+  const [isArm1EncoderOn, setIsArm1EncoderOn] = useState<boolean>(true);
 
   const cameraStates = {
     'rover_cam0': { displayName: 'Rover Cam 0', state: isRoverEncoderOn, setter: setIsRoverEncoderOn },


### PR DESCRIPTION
This is because the node starts the encoders on startup. Better way of doing this is for the encoder_manager_panel to see the state of the services, if that is possible something like a lifecycle thing.